### PR TITLE
Connect directly (skip authServer step) with Twinfield

### DIFF
--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -6,7 +6,7 @@
  * Time: 10:33
  */
 
-namespace Exception;
+namespace PhpTwinfield\Exceptions;
 
 class AuthenticationException extends \Exception
 {

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mainuser
+ * Date: 15/12/2017
+ * Time: 10:33
+ */
+
+namespace Exception;
+
+class AuthenticationException extends \Exception
+{
+
+}

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -113,12 +113,14 @@ final class Config
         $this->setOrganisationAndOffice($org, $office);
     }
 
-    public function setOpenIdDirectConnectCredentials($clientId, $clientSecret, $refreshToken, $accessToken) {
+    public function setOpenIdDirectConnectCredentials($clientId, $clientSecret, $refreshToken, $accessToken, $organisation, $office) {
         $this->openIdDirectConnectCredentials['clientId'] = $clientId;
         $this->openIdDirectConnectCredentials['clientSecret'] = $clientSecret;
         $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
         $this->openIdDirectConnectCredentials['accessToken'] = $accessToken;
+        $this->setOrganisationAndOffice($organisation, $office);
 
+        // Use our own login implementation instead of the deprecated built-in session sign-on and oauth1.
         $this->legacyMode = false;
     }
 

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -118,6 +118,8 @@ final class Config
         $this->openIdDirectConnectCredentials['clientSecret'] = $clientSecret;
         $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
         $this->openIdDirectConnectCredentials['accessToken'] = $accessToken;
+
+        var_dump("1");
         var_dump($office);
 
         $this->setOrganisationAndOffice($organisation, $office);
@@ -251,8 +253,8 @@ final class Config
      */
     public function getOffice()
     {
+        var_dump("2");
         var_dump($this->credentials['office']);
-
 
         return $this->credentials['office'];
     }

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -118,10 +118,6 @@ final class Config
         $this->openIdDirectConnectCredentials['clientSecret'] = $clientSecret;
         $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
         $this->openIdDirectConnectCredentials['accessToken'] = $accessToken;
-
-        var_dump("1");
-        var_dump($office);
-
         $this->setOrganisationAndOffice($organisation, $office);
 
         // Use our own login implementation instead of the deprecated built-in session sign-on and oauth1.
@@ -253,9 +249,6 @@ final class Config
      */
     public function getOffice()
     {
-        var_dump("2");
-        var_dump($this->credentials['office']);
-
         return $this->credentials['office'];
     }
 

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -118,6 +118,8 @@ final class Config
         $this->openIdDirectConnectCredentials['clientSecret'] = $clientSecret;
         $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
         $this->openIdDirectConnectCredentials['accessToken'] = $accessToken;
+        var_dump($office);
+
         $this->setOrganisationAndOffice($organisation, $office);
 
         // Use our own login implementation instead of the deprecated built-in session sign-on and oauth1.
@@ -249,6 +251,9 @@ final class Config
      */
     public function getOffice()
     {
+        var_dump($this->credentials['office']);
+
+
         return $this->credentials['office'];
     }
 

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -62,7 +62,7 @@ final class Config
      * @var array
      */
     private $openIdDirectConnectCredentials = array(
-        'clientToken' => '',
+        'clientId' => '',
         'clientSecret' => '',
         'refreshToken' => '',
         'accessToken' => ''
@@ -113,8 +113,8 @@ final class Config
         $this->setOrganisationAndOffice($org, $office);
     }
 
-    public function setOpenIdDirectConnectCredentials($clientToken, $clientSecret, $refreshToken, $accessToken) {
-        $this->openIdDirectConnectCredentials['clientToken'] = $clientToken;
+    public function setOpenIdDirectConnectCredentials($clientId, $clientSecret, $refreshToken, $accessToken) {
+        $this->openIdDirectConnectCredentials['clientId'] = $clientId;
         $this->openIdDirectConnectCredentials['clientSecret'] = $clientSecret;
         $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
         $this->openIdDirectConnectCredentials['accessToken'] = $accessToken;

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -54,6 +54,26 @@ final class Config
         'clientSecret' => ''
     );
 
+    /**
+     * Holds all the Credentials for OpenID login with a given refresh/accessToken for this
+     * config object
+     *
+     * @access private
+     * @var array
+     */
+    private $openIdDirectConnectCredentials = array(
+        'clientToken' => '',
+        'clientSecret' => '',
+        'refreshToken' => '',
+        'accessToken' => ''
+    );
+
+    /**
+     * Determines whether to use the built in login functionality or our own
+     *
+     * @var bool
+     */
+    private $legacyMode = true;
 
     /**
      * Holds all the OAuth class
@@ -91,6 +111,23 @@ final class Config
         $this->oauthCredentials['autoRedirect'] = $autoRedirect;
         $this->oauthCredentials['clearSession'] = $clearSession;
         $this->setOrganisationAndOffice($org, $office);
+    }
+
+    public function setOpenIdDirectConnectCredentials($clientToken, $clientSecret, $refreshToken, $accessToken) {
+        $this->openIdDirectConnectCredentials['clientToken'] = $clientToken;
+        $this->openIdDirectConnectCredentials['clientSecret'] = $clientSecret;
+        $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
+        $this->openIdDirectConnectCredentials['accessToken'] = $accessToken;
+
+        $this->legacyMode = false;
+    }
+
+    public function getOpenIdDirectConnectCredentials() {
+        return $this->openIdDirectConnectCredentials;
+    }
+
+    public function setRefreshToken($refreshToken) {
+        $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
     }
 
     /**
@@ -259,6 +296,11 @@ final class Config
     public function getSoapClientOptions()
     {
         return $this->soapClientOptions;
+    }
+
+
+    public function isLegacyMode() {
+        return $this->legacyMode;
     }
 
     /**

--- a/src/Secure/Config.php
+++ b/src/Secure/Config.php
@@ -65,7 +65,7 @@ final class Config
         'clientId' => '',
         'clientSecret' => '',
         'refreshToken' => '',
-        'accessToken' => ''
+        'accessToken' => '',
     );
 
     /**
@@ -124,10 +124,6 @@ final class Config
 
     public function getOpenIdDirectConnectCredentials() {
         return $this->openIdDirectConnectCredentials;
-    }
-
-    public function setRefreshToken($refreshToken) {
-        $this->openIdDirectConnectCredentials['refreshToken'] = $refreshToken;
     }
 
     /**

--- a/src/Secure/Login.php
+++ b/src/Secure/Login.php
@@ -94,6 +94,9 @@ class Login
     {
         $this->config = $config;
         $this->office = $config->getOffice();
+
+        var_dump($this->office);
+
         $this->organisation = $config->getOrganisation();
         $this->cluster = !is_null($config->cluster) ? $config->cluster : $this->cluster;
 

--- a/src/Secure/Login.php
+++ b/src/Secure/Login.php
@@ -95,6 +95,7 @@ class Login
         $this->config = $config;
         $this->office = $config->getOffice();
 
+        var_dump("3");
         var_dump($this->office);
 
         $this->organisation = $config->getOrganisation();
@@ -169,6 +170,7 @@ class Login
                     )
                 );
             }else {
+                var_dump("4");
                 var_dump($this->office);
 
                 $this->authenticatedClients[$key]->__setSoapHeaders(

--- a/src/Secure/Login.php
+++ b/src/Secure/Login.php
@@ -87,10 +87,16 @@ class Login
      */
     private $cluster = 'https://c3.twinfield.com';
 
+    private $office;
+    private $organisation;
+
     public function __construct(Config $config)
     {
         $this->config = $config;
+        $this->office = $config->getOffice();
+        $this->organisation = $config->getOrganisation();
         $this->cluster = !is_null($config->cluster) ? $config->cluster : $this->cluster;
+
         $this->loginService = new LoginService(
             null,
             $config->getSoapClientOptions()
@@ -110,7 +116,7 @@ class Login
             [$this->sessionID, $this->cluster] = $this->loginService->getSessionIdAndCluster($this->config);
         }else {
             // If accessToken is still valid, don't try to retrieve it.
-            if($this->expire && time() <= $this->expire) {
+            if ($this->expire && time() <= $this->expire) {
                 return;
             }
 
@@ -159,16 +165,18 @@ class Login
                         ['SessionID' => $this->sessionID]
                     )
                 );
-            } else {
+            }else {
                 $this->authenticatedClients[$key]->__setSoapHeaders(
                     new \SoapHeader(
                         'http://www.twinfield.com/',
                         'Header',
-                        ['AccessToken' => $this->accessToken]
+                        [
+                            'AccessToken' => $this->accessToken,
+                            'CompanyCode' => $this->office,
+                        ]
                     )
                 );
             }
-
         }
 
         return $this->authenticatedClients[$key];

--- a/src/Secure/Login.php
+++ b/src/Secure/Login.php
@@ -166,13 +166,15 @@ class Login
                     )
                 );
             }else {
+                var_dump($this->office);
+
                 $this->authenticatedClients[$key]->__setSoapHeaders(
                     new \SoapHeader(
                         'http://www.twinfield.com/',
                         'Header',
                         [
-                            'AccessToken' => $this->accessToken,
                             'CompanyCode' => $this->office,
+                            'AccessToken' => $this->accessToken,
                         ]
                     )
                 );

--- a/src/Secure/Login.php
+++ b/src/Secure/Login.php
@@ -94,10 +94,6 @@ class Login
     {
         $this->config = $config;
         $this->office = $config->getOffice();
-
-        var_dump("3");
-        var_dump($this->office);
-
         $this->organisation = $config->getOrganisation();
         $this->cluster = !is_null($config->cluster) ? $config->cluster : $this->cluster;
 
@@ -170,9 +166,6 @@ class Login
                     )
                 );
             }else {
-                var_dump("4");
-                var_dump($this->office);
-
                 $this->authenticatedClients[$key]->__setSoapHeaders(
                     new \SoapHeader(
                         'http://www.twinfield.com/',

--- a/src/Secure/Login.php
+++ b/src/Secure/Login.php
@@ -56,6 +56,28 @@ class Login
      */
     private $sessionID;
 
+
+    /**
+     * The refreshToken for openID login
+     *
+     * @var string
+     */
+    private $refreshToken;
+
+    /**
+     * The accessToken for openID login
+     *
+     * @var string
+     */
+    private $accessToken;
+
+    /**
+     * The expiry timestamp for the openID accessToken
+     *
+     * @var string
+     */
+    private $expire;
+
     /**
      * The server cluster used for future XML
      * requests with the new SoapClient
@@ -86,8 +108,14 @@ class Login
             }
 
             [$this->sessionID, $this->cluster] = $this->loginService->getSessionIdAndCluster($this->config);
-        } else {
-            $this->loginService->getRefreshAndAccessToken($this->config);
+        }else {
+            // Retrieve refresh/acccessToken
+            [$this->refreshToken, $this->accessToken] = $this->loginService->getRefreshAndAccessToken($this->config);
+
+            [$this->cluster, $this->expire] = $this->loginService->getClusterAndExpire(
+                $this->config,
+                $this->accessToken
+            );
         }
     }
 

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -95,7 +95,7 @@ class LoginService extends BaseService
     }
 
     public function getClusterAndExpire(string $accessToken): array {
-        $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation";
+        $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidationzzz";
 
         // Setup cURL
         $ch = curl_init("$url?token=$accessToken");
@@ -108,13 +108,12 @@ class LoginService extends BaseService
         ));
 
         // Send the request
-//        $response = curl_exec($ch);
-        $response = false;
-
+        $response = curl_exec($ch);
 
         // Check for errors
         if($response === FALSE){
-            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield", null, $response);
+            var_dump($response);
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield");
         }
 
         // Decode the response

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -117,7 +117,6 @@ class LoginService extends BaseService
 
         // Decode the response
         $responseData = json_decode($response, TRUE);
-        var_dump($responseData);
 
         $cluster = $responseData['twf.clusterUrl'];
         $expire = $responseData['exp'];

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -95,7 +95,7 @@ class LoginService extends BaseService
     }
 
     public function getClusterAndExpire(string $accessToken): array {
-        $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidationzzz";
+        $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation";
 
         // Setup cURL
         $ch = curl_init("$url?token=$accessToken");

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -83,11 +83,16 @@ class LoginService extends BaseService
 
         // Check for errors
         if($response === FALSE){
-            die(curl_error($ch));
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield: " . curl_error($ch));
         }
 
         // Decode the response
         $responseData = json_decode($response, TRUE);
+
+        if (!array_key_exists("refresh_token", $responseData) || !array_key_exists("access_token", $responseData)) {
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield: " . json_encode($responseData));
+        }
+
         $refreshToken = $responseData['refresh_token'];
         $accessToken = $responseData['access_token'];
 
@@ -112,7 +117,7 @@ class LoginService extends BaseService
 
         // Check for errors
         if($response === FALSE){
-            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield");
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield: " . curl_error($ch));
         }
 
         // Decode the response

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -93,8 +93,7 @@ class LoginService extends BaseService
         return [$refreshToken, $accessToken];
     }
 
-    public function getClusterAndExpire(Config $config, string $accessToken): array {
-
+    public function getClusterAndExpire(string $accessToken): array {
         $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation";
 
         // Setup cURL

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -59,7 +59,7 @@ class LoginService extends BaseService
     {
         $configClientId = $config->getOpenIdDirectConnectCredentials()['clientId'];
         $configClientSecret = $config->getOpenIdDirectConnectCredentials()['clientSecret'];
-        $configRefreshToken = $config->getOpenIdDirectConnectCredentials()['refreshToken'];;
+        $configRefreshToken = $config->getOpenIdDirectConnectCredentials()['refreshToken'];
 
         $url = 'https://login.twinfield.com/auth/authentication/connect/token';
         $authString = base64_encode("$configClientId:$configClientSecret");
@@ -70,7 +70,7 @@ class LoginService extends BaseService
             CURLOPT_POST => TRUE,
             CURLOPT_RETURNTRANSFER => TRUE,
             CURLOPT_HTTPHEADER => array(
-                "Authorization: $authString",
+                "Authorization: Basic $authString",
                 'Content-Type: application/x-www-form-urlencoded',
                 'host: login.twinfield.com'
             ),

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -109,12 +109,9 @@ class LoginService extends BaseService
 
         // Send the request
         $response = curl_exec($ch);
-        var_dump($response);
-
 
         // Check for errors
         if($response === FALSE){
-            var_dump($response);
             throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield");
         }
 
@@ -123,6 +120,10 @@ class LoginService extends BaseService
 
         $cluster = $responseData['twf.clusterUrl'];
         $expire = $responseData['exp'];
+
+        if ($cluster === null || $expire === null) {
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield", 1, $responseData);
+        }
 
         return [$cluster, $expire];
     }

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -8,12 +8,12 @@ use PhpTwinfield\Secure\Config;
 class LoginService extends BaseService
 {
     /**
-     * Login based on the config.
-     *
-     * @param Config $config
-     * @throws Exception
-     * @return string[]
-     */
+ * Login based on the config.
+ *
+ * @param Config $config
+ * @throws Exception
+ * @return string[]
+ */
     public function getSessionIdAndCluster(Config $config): array
     {
         // Process logon
@@ -46,6 +46,50 @@ class LoginService extends BaseService
         $cluster = $clusterElements->item(0)->textContent;
 
         return [$sessionId, $cluster];
+    }
+
+    /**
+     * Login based on the config.
+     *
+     * @param Config $config
+     * @throws Exception
+     * @return string[]
+     */
+    public function getRefreshAndAccessToken(Config $config): array
+    {
+        $configClientId = $config->getOpenIdDirectConnectCredentials()['clientId'];
+        $configClientSecret = $config->getOpenIdDirectConnectCredentials()['clientSecret'];
+        $configRefreshToken = $config->getOpenIdDirectConnectCredentials()['refreshToken'];;
+
+        $url = 'https://login.twinfield.com/auth/authentication/connect/token';
+        $authString = base64_encode("$configClientId:$configClientSecret");
+
+        // Setup cURL
+        $ch = curl_init($url);
+        curl_setopt_array($ch, array(
+            CURLOPT_POST => TRUE,
+            CURLOPT_RETURNTRANSFER => TRUE,
+            CURLOPT_HTTPHEADER => array(
+                "Authorization: $authString",
+                'Content-Type: application/x-www-form-urlencoded',
+                'host: login.twinfield.com'
+            ),
+            CURLOPT_POSTFIELDS => "grant_type=refresh_token&refresh_token=$configRefreshToken"
+        ));
+
+        // Send the request
+        $response = curl_exec($ch);
+
+        // Check for errors
+        if($response === FALSE){
+            die(curl_error($ch));
+        }
+
+        // Decode the response
+        $responseData = json_decode($response, TRUE);
+        var_dump($responseData);
+
+        return [$configRefreshToken, $accessToken];
     }
 
     protected function WSDL(): string

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -118,12 +118,12 @@ class LoginService extends BaseService
         // Decode the response
         $responseData = json_decode($response, TRUE);
 
-        $cluster = $responseData['twf.clusterUrl'];
-        $expire = $responseData['exp'];
-
-        if ($cluster === null || $expire === null) {
+        if (!array_key_exists("twf.clusterUrl", $responseData) || !array_key_exists("exp", $responseData)) {
             throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield", 1, $responseData);
         }
+
+        $cluster = $responseData['twf.clusterUrl'];
+        $expire = $responseData['exp'];
 
         return [$cluster, $expire];
     }

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -119,7 +119,7 @@ class LoginService extends BaseService
         $responseData = json_decode($response, TRUE);
 
         if (!array_key_exists("twf.clusterUrl", $responseData) || !array_key_exists("exp", $responseData)) {
-            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield: $responseData");
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield: " . json_encode($responseData));
         }
 
         $cluster = $responseData['twf.clusterUrl'];

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -98,7 +98,7 @@ class LoginService extends BaseService
         $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation";
 
         // Setup cURL
-        $ch = curl_init("$url?token=$accessToken");
+        $ch = curl_init("$url?token=Z$accessToken");
         curl_setopt_array($ch, array(
             CURLOPT_POST => FALSE,
             CURLOPT_RETURNTRANSFER => TRUE,

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -109,6 +109,8 @@ class LoginService extends BaseService
 
         // Send the request
         $response = curl_exec($ch);
+        var_dump($response);
+
 
         // Check for errors
         if($response === FALSE){

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -87,9 +87,42 @@ class LoginService extends BaseService
 
         // Decode the response
         $responseData = json_decode($response, TRUE);
+        $refreshToken = $responseData['refresh_token'];
+        $accessToken = $responseData['access_token'];
+
+        return [$refreshToken, $accessToken];
+    }
+
+    public function getClusterAndExpire(Config $config, string $accessToken): array {
+
+        $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation";
+
+        // Setup cURL
+        $ch = curl_init("$url?token=$accessToken");
+        curl_setopt_array($ch, array(
+            CURLOPT_POST => FALSE,
+            CURLOPT_RETURNTRANSFER => TRUE,
+            CURLOPT_HTTPHEADER => array(
+                'host: login.twinfield.com'
+            )
+        ));
+
+        // Send the request
+        $response = curl_exec($ch);
+
+        // Check for errors
+        if($response === FALSE){
+            die(curl_error($ch));
+        }
+
+        // Decode the response
+        $responseData = json_decode($response, TRUE);
         var_dump($responseData);
 
-        return [$configRefreshToken, $accessToken];
+        $cluster = $responseData['twf.clusterUrl'];
+        $expire = $responseData['exp'];
+
+        return [$cluster, $expire];
     }
 
     protected function WSDL(): string

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\Services;
 
+use Exception\AuthenticationException;
 use PhpTwinfield\Exception;
 use PhpTwinfield\Secure\Config;
 
@@ -107,11 +108,13 @@ class LoginService extends BaseService
         ));
 
         // Send the request
-        $response = curl_exec($ch);
+//        $response = curl_exec($ch);
+        $response = false;
+
 
         // Check for errors
         if($response === FALSE){
-            die(curl_error($ch));
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield", null, $response);
         }
 
         // Decode the response

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -2,8 +2,8 @@
 
 namespace PhpTwinfield\Services;
 
-use Exception\AuthenticationException;
 use PhpTwinfield\Exception;
+use PhpTwinfield\Exceptions\AuthenticationException;
 use PhpTwinfield\Secure\Config;
 
 class LoginService extends BaseService

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -119,7 +119,7 @@ class LoginService extends BaseService
         $responseData = json_decode($response, TRUE);
 
         if (!array_key_exists("twf.clusterUrl", $responseData) || !array_key_exists("exp", $responseData)) {
-            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield", 1, $responseData);
+            throw new AuthenticationException("Something went wrong while retrieving the Cluster and AccessToken expire time from Twinfield: $responseData");
         }
 
         $cluster = $responseData['twf.clusterUrl'];

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -98,7 +98,7 @@ class LoginService extends BaseService
         $url = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation";
 
         // Setup cURL
-        $ch = curl_init("$url?token=Z$accessToken");
+        $ch = curl_init("$url?token=$accessToken");
         curl_setopt_array($ch, array(
             CURLOPT_POST => FALSE,
             CURLOPT_RETURNTRANSFER => TRUE,


### PR DESCRIPTION
# Status
READY

# Description
* added a authentication mode to the SDK which is based on the OpenID authentication that allows you to enter certain parameters (accessToken, refreshToken, clientId, clientSecret) to skip the authentication process and connect to Twinfield directly.

This is useful if you just want to test some calls without having to go through the authorization process.

There already was an direct Connect using session logon in place, but this authentication method is marked as deprecated by Twinfield so I implemented it using OpenId to avoid future complications.